### PR TITLE
feat(parser): resolve animejs import errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@remotion/bundler": "4.0.334",
         "@remotion/player": "^4.0.334",
         "@remotion/renderer": "4.0.334",
-        "animejs": "^3.2.1",
+        "animejs": "^3.2.2",
         "cors": "^2.8.5",
         "express": "^4.21.2",
         "fs": "^0.0.1-security",
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/animejs": "^3.1.13",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -2056,6 +2057,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@types/animejs": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@types/animejs/-/animejs-3.1.13.tgz",
+      "integrity": "sha512-yWg9l1z7CAv/TKpty4/vupEh24jDGUZXv4r26StRkpUPQm04ztJaftgpto8vwdFs8SiTq6XfaPKCSI+wjzNMvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@remotion/bundler": "4.0.334",
     "@remotion/player": "^4.0.334",
     "@remotion/renderer": "4.0.334",
+    "animejs": "^3.2.2",
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "fs": "^0.0.1-security",
@@ -20,11 +21,11 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "remotion": "4.0.334",
-    "animejs": "^3.2.1",
     "yaml": "2.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/animejs": "^3.1.13",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/src/animejs.d.ts
+++ b/src/animejs.d.ts
@@ -1,0 +1,1 @@
+declare module 'animejs';

--- a/src/parser/index.tsx
+++ b/src/parser/index.tsx
@@ -1,7 +1,8 @@
 import React, {CSSProperties, useMemo} from 'react'
 import {interpolate, useCurrentFrame, Easing} from 'remotion'
 import YAML from 'yaml'
-import {createTimeline, stagger as animeStagger} from 'animejs'
+import anime from 'animejs'
+const {timeline: createTimeline, stagger: animeStagger} = anime
 // Types describing the YAML schema
 
 type PercentString = `${number}%`


### PR DESCRIPTION
Addresses two issues related to importing the `animejs` library in a TypeScript project.

- Resolves a TypeScript error by adding a custom animejs.d.ts declaration file.
- Fixes a runtime error by correcting the import statement to use the default export as required by `animejs`.